### PR TITLE
2 experiment transients, FATES working with I20TR compset: walkeranthonyp/cleanup runcaseopts

### DIFF
--- a/makepointdata.py
+++ b/makepointdata.py
@@ -489,6 +489,7 @@ for n in range(0,n_grids):
                         organic[k][0][0] = 130.0
                     elif (k == 8):
                         organic[k][0][0] = 65.0
+            # APW: this assumes that PFT labels do not change in the PFT file, consider reading from param file
             pft_names=['Bare ground','ENF Temperate','ENF Boreal','DNF Boreal','EBF Tropical', \
                        'EBF Temperate', 'DBF Tropical', 'DBF Temperate', 'DBF Boreal', 'EB Shrub' \
                        , 'DB Shrub Temperate', 'BD Shrub Boreal', 'C3 arctic grass', \

--- a/plotcase.py
+++ b/plotcase.py
@@ -202,12 +202,12 @@ print('')
 print('Simulations that will be plotted:')
 print(runnames)
 print('')
-print(mycases1)
-print('')
-print(mysites1)
-print('')
-print(mycompsets1)
-print('')
+#print(mycases1)
+#print('')
+#print(mysites1)
+#print('')
+#print(mycompsets1)
+#print('')
 #sys.exit(0)
 
 obs     = options.myobs
@@ -786,8 +786,10 @@ for v in range(0,len(myvars)):
         plt.ylabel(myvars[v]+' ('+var_units[v]+')')
         box = ax.get_position()
         ax.set_position([box.x0, box.y0, box.width * 0.8, box.height])
-        if (v % options.nperpage == options.nperpage-1):
-          ax.legend(loc='center left', bbox_to_anchor=(1, 0.5),prop={'size': 10})
+        #if (v % options.nperpage == options.nperpage-1):
+        #  ax.legend(loc='center left', bbox_to_anchor=(1, 0.5),prop={'size': 10})
+        if (v % options.nperpage == 0):
+          ax.legend(loc='upper left', bbox_to_anchor=(0, 1.3), prop={'size': 8}, ncol=2)
         plt.title(var_long_names[v]) #+' at '+mysites[0])
         if (options.ylog):
             plt.yscale('log')

--- a/plotcase.py
+++ b/plotcase.py
@@ -23,13 +23,11 @@ def getvar(fname, varname, npf, index, scale_factor):
         nffile = netcdf.NetCDFFile(fname,"r")
         var = nffile.variables[varname]
         varvals = var.getValue()[0:npf,index] * scale_factor
-        nffile.close()
+        #nffile.close()
     return varvals
 
 
 parser = OptionParser()
-parser.add_option("--ad_Pinit", dest="ad_Pinit", default=False, action="store_true",\
-                  help="Initialize AD spinup with P pools and use CNP mode")
 parser.add_option("--csmdir", dest="mycsmdir", default='', \
                   help = 'Base CESM directory (default = ..)')
 parser.add_option("--cases", dest="mycase", default='', \
@@ -38,17 +36,19 @@ parser.add_option("--compset", dest="compset", default="I20TRCLM45CN", \
                   help = "Compset to plot")
 parser.add_option("--titles", dest="titles", default='', \
                   help = "titles of case to plot (for legend)")
-parser.add_option("--obs", action="store_true", default=False, \
-                  help = "plot observations", dest="myobs")
 parser.add_option("--sites", dest="site", default="none", \
                   help = 'site (to plot observations)')
-parser.add_option("--timezone", dest="timezone", default=0, \
-                  help = 'time zone (relative to UTC')
+parser.add_option("--obs", action="store_true", default=False, \
+                  help = "plot observations", dest="myobs")
 parser.add_option("--varfile", dest="myvarfile", default='varfile', \
                   help = 'file containing list of variables to plot')
 parser.add_option("--vars", dest="myvar", default='', \
                   help="variable to plot (overrides varfile, " \
                   +"sends plot to screen")
+
+# output timing
+parser.add_option("--timezone", dest="timezone", default=0, \
+                  help = 'time zone (relative to UTC')
 parser.add_option("--avpd", dest="myavpd", default=1, \
                   help = 'averaging period in # of output timesteps' \
                   +' (default = 1)')
@@ -82,8 +82,12 @@ parser.add_option("--h4", dest="h4", default=False, \
                   action="store_true", help = 'Use h4 history files')
 parser.add_option("--index", dest="index", help = 'index (site or pft)', \
                    default=0)
+
+# plot configuration
 parser.add_option("--spinup", dest="spinup", help = 'plot Ad and final spinup', \
                    default=False, action="store_true")
+parser.add_option("--ad_Pinit", dest="ad_Pinit", default=False, action="store_true",\
+                  help="AD spinup initialized with P pools (CN) but other cases use CNP mode")
 parser.add_option("--scale_factor", dest="scale_factor", help = 'scale factor', \
                    default=-999)
 parser.add_option("--ylog", dest="ylog", help="log scale for Y axis", \
@@ -490,7 +494,7 @@ for c in range(0,ncases):
             if (npf == 1):
                 starti = 1
             for n in range(0,nc):
-                if ((options.spinup)and n== 0):
+                if ((options.spinup) and n== 0):
 #                    if (mycases[c] == ''):
 #                        if (options.ad_Pinit):
 #                            mydir = cesmdir+'/'+mysites[c]+'_'+mycompsets[c]+'_ad_spinup/run/'
@@ -701,7 +705,7 @@ for v in range(0,len(myvars)):
                 ftype_suffix=['model','obs']
                 os.system('mkdir -p ./plots/'+mycases[0]+'/'+analysis_type)
                 for ftype in range(0,2):
-                    outdata = netcdf.netcdf_file('./plots/'+mycases[0]+'/'+analysis_type+'/'+mycases[0]+"_"+mysites[0]+'_'+ftype_suffix[ftype]+".nc","w",mmap=False)
+                    outdata = netcdf.netcdf_file('./plots/'+mycases[0]+'/'+analysis_type+'/'+mycases[0]+"_"+mysites[0]+'_'+mycompsets[0]+'_'+ftype_suffix[ftype]+".nc","w",mmap=False)
                     outdata.createDimension('time',snum[c])
                     #outdata.createDimension('lat',ncases)
                     #outdata.createDimension('lon',ncases)
@@ -723,7 +727,7 @@ for v in range(0,len(myvars)):
                     myname[:,:] = ' '   #changed for gridcell
                     outdata.close()
         for ftype in range(0,2):
-            outdata = netcdf.netcdf_file('./plots/'+mycases[0]+'/'+analysis_type+'/'+mycases[0]+"_"+mysites[0]+'_'+ftype_suffix[ftype]+".nc","a",mmap=False)
+            outdata = netcdf.netcdf_file('./plots/'+mycases[0]+'/'+analysis_type+'/'+mycases[0]+"_"+mysites[0]+'_'+mycompsets[0]+'_'+ftype_suffix[ftype]+".nc","a",mmap=False)
             if (c == 0):
                 #myvar = outdata.createVariable(myvars[v],'f',('time','lat','lon'))
                 myvar = outdata.createVariable(myvars[v],'f',('time','gridcell'))
@@ -796,9 +800,9 @@ for v in range(0,len(myvars)):
 
         os.system('mkdir -p ./plots/'+mycases[0]+'/'+analysis_type)
         if (options.nperpage == 1):
-          fig_filename = './plots/'+mycases[0]+'/'+analysis_type+'/'+mysites[0]+'_'+myvars[v]+'_'+analysis_type
+          fig_filename = './plots/'+mycases[0]+'/'+analysis_type+'/'+mysites[0]+'_'+mycompsets[0]+'_'+myvars[v]+'_'+analysis_type
         else:
-          fig_filename = './plots/'+mycases[0]+'/'+analysis_type+'/'+mysites[0]+'_fig'+str(fignum)+'_'+analysis_type
+          fig_filename = './plots/'+mycases[0]+'/'+analysis_type+'/'+mysites[0]+'_'+mycompsets[0]+'_fig'+str(fignum)+'_'+analysis_type
         if (options.pdf):
             fig.savefig(fig_filename+'.pdf')
         if (options.png):

--- a/plotcase.py
+++ b/plotcase.py
@@ -109,37 +109,106 @@ mycases = options.mycase.split(',')
 mysites = options.site.split(',')
 mycompsets = options.compset.split(',')
 
+print('')
+print(mycases)
+print(mysites)
+print(mycompsets)
+
 ncases = 1
-if (len(mycases) > 1):
-  ncases = len(mycases)
-  mysites=[]
-  for c in range(0,ncases):
-    mysites.append(options.site)
-    #if (len(mycompsets) == 1):
-    mycompsets.append(options.compset)
-  mytitles = mycases
-elif (len(mysites) > 1):
-  ncases = len(mysites)
-  mycases=[]
-  mycompsets=[]
-  for c in range(0,ncases):
-    mycases.append(options.mycase)
-    mycompsets.append(options.compset)
-  mytitles = mysites
-elif (len(mycompsets) > 1):
-  ncases = len(mycompsets)
-  mycases=[]
-  mysites=[]
-  for c in range(0,ncases):
-    mycases.append(options.mycase)
-    mysites.append(options.site)  
-  mytitles = mycompsets
+#if (len(mycases) > 1):
+#  ncases = len(mycases)
+#  mysites=[]
+#  for c in range(0,ncases):
+#    mysites.append(options.site)
+#    #if (len(mycompsets) == 1):
+#    mycompsets.append(options.compset)
+#  mytitles = mycases
+#elif (len(mysites) > 1):
+#  ncases = len(mysites)
+#  mycases=[]
+#  mycompsets=[]
+#  for c in range(0,ncases):
+#    mycases.append(options.mycase)
+#    mycompsets.append(options.compset)
+#  mytitles = mysites
+#elif (len(mycompsets) > 1):
+#  ncases = len(mycompsets)
+#  mycases=[]
+#  mysites=[]
+#  for c in range(0,ncases):
+#    mycases.append(options.mycase)
+#    mysites.append(options.site)  
+#  mytitles = mycompsets
+#else:
+#  mytitles=[]
+#  mytitles.append(mysites[0])
+#
+#if (options.titles != ''):
+#  mytitles = options.titles.split(',')
+
+mysites1 = numpy.char.add(mysites,'_')
+mysites2 = mysites1
+if (len(mycompsets) > 1):
+  for c in range(1,len(mycompsets)):
+    mysites2 = numpy.concatenate((mysites2,mysites1))
+mycompsets1 = numpy.repeat(mycompsets, len(mysites) )
+runnames = numpy.char.add(mysites2,mycompsets1)
+mysites1 = mysites2
+
+if (len(mycases) == 0):
+  if (mycases[0] != ''):
+    mycases1 = numpy.char.add(mycases,'_') 
+    mycases2 = mycases1
+    for c in range(1,len(runnames)):
+      mycases2 = numpy.concatenate((mycases2,mycases1))
+    runnames = numpy.concatenate((mycases2,runnames))
+    mycases1 = mycases2
+  else:
+    mycases1 = mycases
+    for c in range(1,len(runnames)):
+      mycases1 = numpy.concatenate((mycases1,mycases))
+
 else:
-  mytitles=[]
-  mytitles.append(mysites[0])
+  runnames1 = runnames 
+  mysites3  = mysites2
+  mycompsets2 = mycompsets1
+  #print(mycases)
+  for c in range(1,len(mycases)):
+    runnames1   = numpy.concatenate((runnames1,runnames))
+    mysites3    = numpy.concatenate((mysites3,mysites2))
+    mycompsets2 = numpy.concatenate((mycompsets2,mycompsets1))
+  mysites1  = mysites3
+  mycompsets1 = mycompsets2
+  mycases1 = mycases
+  #print(mycases)
+  for c in range(0,len(mycases1)):
+    if (mycases1[c] != ''):
+      mycases1[c] = mycases1[c]+'_'
+      #print(mycases)
+  mycases1 = numpy.repeat(mycases1, len(runnames) )
+  runnames = numpy.char.add(mycases1,runnames1) 
+  #print(mycases)
+
+mycases = options.mycase.split(',') # APW: IDK why but this is necessary as the above code is adding _ to mycases
+ncases = len(runnames)
 
 if (options.titles != ''):
   mytitles = options.titles.split(',')
+else:
+  mytitles = runnames
+
+print('')
+print('')
+print('Simulations that will be plotted:')
+print(runnames)
+print('')
+print(mycases1)
+print('')
+print(mysites1)
+print('')
+print(mycompsets1)
+print('')
+#sys.exit(0)
 
 obs     = options.myobs
 myobsdir = '/lustre/or-hydra/cades-ccsi/scratch/dmricciuto/fluxnet'
@@ -189,12 +258,15 @@ err_toplot  = numpy.zeros([ncases, nvar, 2000000], numpy.float)+numpy.NaN
 snum        = numpy.zeros([ncases], numpy.int)
 
 for c in range(0,ncases):
-    if (mycases[c] == ''):
-        mydir = cesmdir+'/'+mysites[c]+'_'+mycompsets[c]+'/run/'
-    else:
-        mydir = cesmdir+'/'+mycases[c]+'_'+mysites[c]+'_'+mycompsets[c]+'/run/'
+    mydir = cesmdir+'/'+runnames[c]+'/run/'
+#    if (mycases[c] == ''):
+#        mydir = cesmdir+'/'+mysites[c]+'_'+mycompsets[c]+'/run/'
+#    else:
+#        mydir = cesmdir+'/'+mycases[c]+'_'+mysites[c]+'_'+mycompsets[c]+'/run/'
+    print('')
     print('Processing '+mydir)
-
+    #if (os.path.exists(mydir)):
+    #else:
     #query lnd_in file for output file information
     if ((options.myhist_mfilt == -999 or options.myhist_nhtfrq == -999)):
         #print('Obtaining output resolution information from lnd_in')
@@ -362,8 +434,9 @@ for c in range(0,ncases):
                 yst=str(10000+y)[1:5]
                 for m in range(0,12):
                     mst=str(101+m)[1:3]
-                    myfile = os.path.abspath(mydir+'/'+mycases[c]+'_'+mysites[c]+'_'+mycompsets[c]+ \
-                                             ".clm2."+hst+"."+yst+"-"+mst+".nc")
+                    #myfile = os.path.abspath(mydir+'/'+mycases[c]+'_'+mysites[c]+'_'+mycompsets[c]+ \
+                    #                         ".clm2."+hst+"."+yst+"-"+mst+".nc")
+                    myfile = os.path.abspath(mydir+'/'+runnames[c]+".clm2."+hst+"."+yst+"-"+mst+".nc")
                     #get units/long names from first file
                     if (os.path.exists(myfile)):
                         if (y == ystart and m == 0 and c == 0):
@@ -418,36 +491,47 @@ for c in range(0,ncases):
                 starti = 1
             for n in range(0,nc):
                 if ((options.spinup)and n== 0):
-                    if (mycases[c] == ''):
-                        if (options.ad_Pinit):
-                            mydir = cesmdir+'/'+mysites[c]+'_'+mycompsets[c]+'_ad_spinup/run/'
-                        else:
-                            mydir = cesmdir+'/'+mysites[c]+'_'+mycompsets[c].replace('CNP','CN')+ \
-	                          '_ad_spinup/run/'
+#                    if (mycases[c] == ''):
+#                        if (options.ad_Pinit):
+#                            mydir = cesmdir+'/'+mysites[c]+'_'+mycompsets[c]+'_ad_spinup/run/'
+#                        else:
+#                            mydir = cesmdir+'/'+mysites[c]+'_'+mycompsets[c].replace('CNP','CN')+ \
+#	                          '_ad_spinup/run/'
+#                    else:
+#                        if (options.ad_Pinit):
+#                            mydir = cesmdir+'/'+mycases[c]+'_'+mysites[c]+'_'+ \
+#                                    mycompsets[c]+'_ad_spinup/run/'
+#                            thiscompset = mycompsets[c]+'_ad_spinup'
+#                        else:
+#                            mydir = cesmdir+'/'+mycases[c]+'_'+mysites[c]+'_'+ \
+#                                    mycompsets[c].replace('CNP','CN')+'_ad_spinup/run/'
+#                            thiscompset = mycompsets[c].replace('CNP','CN')+'_ad_spinup'
+                    if (options.ad_Pinit):
+                        mydir = cesmdir+'/'+mycases1[c]+mysites1[c]+mycompsets1[c]+'_ad_spinup/run/'
+                        thiscompset = mycompsets1[c]+'_ad_spinup'
                     else:
-                        if (options.ad_Pinit):
-                            mydir = cesmdir+'/'+mycases[c]+'_'+mysites[c]+'_'+ \
-                                    mycompsets[c]+'_ad_spinup/run/'
-                            thiscompset = mycompsets[c]+'_ad_spinup'
-                        else:
-                            mydir = cesmdir+'/'+mycases[c]+'_'+mysites[c]+'_'+ \
-                                    mycompsets[c].replace('CNP','CN')+'_ad_spinup/run/'
-                            thiscompset = mycompsets[c].replace('CNP','CN')+'_ad_spinup'
+                        mydir = cesmdir+'/'+mycases1[c]+mysites1[c]+ \
+                                mycompsets1[c].replace('CNP','CN')+'_ad_spinup/run/'
+                        thiscompset = mycompsets1[c].replace('CNP','CN')+'_ad_spinup'
                 else:
-                    if (mycases[c] == ''):
-                        mydir = cesmdir+'/'+mysites[c]+'_'+mycompsets[c]+'/run/'
-                    else:
-                        mydir = cesmdir+'/'+mycases[c]+'_'+mysites[c]+'_'+ \
-                                mycompsets[c]+'/run/'
-                    thiscompset = mycompsets[c]
+#                    if (mycases[c] == ''):
+#                        mydir = cesmdir+'/'+mysites[c]+'_'+mycompsets[c]+'/run/'
+#                    else:
+#                        mydir = cesmdir+'/'+mycases[c]+'_'+mysites[c]+'_'+ \
+#                                mycompsets[c]+'/run/'
+#                    thiscompset = mycompsets[c]
+                    mydir = cesmdir+'/'+mycases1[c]+mysites1[c]+mycompsets1[c]+'/run/'
+                    thiscompset = mycompsets1[c]
                 for y in range(starti,nfiles+1):   #skip first file in spinup
                     yst=str(10000+ystart+(y*nypf))[1:5]
-                    if (mycases[c].strip() == ''):
-                        myfile = os.path.abspath(mydir+'/'+mycases[c]+'_'+thiscompset+".clm2."+hst+ \
-                                                 "."+yst+"-01-01-00000.nc")
-                    else:
-                        myfile = os.path.abspath(mydir+'/'+mycases[c]+"_"+mysites[c]+'_'+thiscompset+ \
-                                                 ".clm2."+hst+"."+yst+"-01-01-00000.nc")
+#                    if (mycases[c].strip() == ''):
+#                        myfile = os.path.abspath(mydir+'/'+mycases[c]+'_'+thiscompset+".clm2."+hst+ \
+#                                                 "."+yst+"-01-01-00000.nc")
+#                    else:
+#                        myfile = os.path.abspath(mydir+'/'+mycases[c]+"_"+mysites[c]+'_'+thiscompset+ \
+#                                                 ".clm2."+hst+"."+yst+"-01-01-00000.nc")
+                    myfile = os.path.abspath(mydir+'/'+mycases1[c]+mysites1[c]+thiscompset+ \
+                                             ".clm2."+hst+"."+yst+"-01-01-00000.nc")
                     if (os.path.exists(myfile)):
                         if (n == 0):
                             ylast = y
@@ -658,7 +742,8 @@ for v in range(0,len(myvars)):
                 myvar[:,c] = obs_toplot[c,v,0:snum[c]]*scalefac   #changed for gridcell
             if (v == 0):
                 myname = outdata.variables['site_name']
-                myname[c,0:6] = str(mysites[c])[0:6]   #changed for gridcell
+                #myname[c,0:6] = str(mysites[c])[0:6]   #changed for gridcell
+                myname[c,0:6] = str(mysites1[c])[0:6]   #changed for gridcell
                 mylat = outdata.variables['lat']
                 mylat[c] = mylat_vals[c]
                 mylon = outdata.variables['lon']

--- a/runcase.py
+++ b/runcase.py
@@ -22,66 +22,102 @@ from optparse import OptionParser
 parser = OptionParser()
 
 # general OLMT options
-
-
 parser.add_option("--caseidprefix", dest="mycaseid", default="", \
                   help="Unique identifier to include as a prefix to the case name")
 parser.add_option("--caseroot", dest="caseroot", default='', \
                   help = "case root directory (default = ./, i.e., under scripts/)")
-parser.add_option("--constraints", dest="constraints", default="", \
-                  help="Directory containing model constraints")
-parser.add_option("--dailyrunoff", dest="dailyrunoff", default=False, \
-                 action="store_true", help="Write daily output for hydrology")
-parser.add_option("--diags", dest="diags", default=False, \
-                 action="store_true", help="Write special outputs for diagnostics")
-parser.add_option("--debugq", dest="debug", default=False, \
-                 action="store_true", help='Use debug queue')
 parser.add_option("--runroot", dest="runroot", default="", \
                   help="Directory where the run would be created")
+parser.add_option("--model_root", dest="csmdir", default='', \
+                  help = "base model directory")
+parser.add_option("--ccsm_input", dest="ccsm_input", default='', \
+                  help = "input data directory for CESM (required)")
 parser.add_option('--project', dest='project',default='', \
                  help='Set project')
 parser.add_option("--exeroot", dest="exeroot", default="", \
 	         help="Location of executable")
-parser.add_option("--istrans", dest="istrans", default=False, action="store_true",\
-                 help="Force compset to act like transient")
-parser.add_option("--lat_bounds", dest="lat_bounds", default='-999,-999', \
-                  help = 'latitude range for regional run')
-parser.add_option("--lon_bounds", dest="lon_bounds", default='-999,-999', \
-                  help = 'longitude range for regional run')
-parser.add_option("--humhol", dest="humhol", default=False, \
-                  help = 'Use hummock/hollow microtopography', action="store_true")
-parser.add_option("--mask", dest="mymask", default='', \
-                  help = 'Mask file to use (regional only)')
+parser.add_option("--constraints", dest="constraints", default="", \
+                  help="Directory containing model constraints")
 parser.add_option("--metdata_dir", dest="metdata_dir", default='', \
                   help = 'Directory containing cpl_bypass met data (site only)')
-parser.add_option("--model", dest="mymodel", default='', \
-                  help = 'Model to use (ELM,CLM5)')
-parser.add_option("--monthly_metdata", dest="monthly_metdata", default = '', \
-                  help = "File containing met data (cpl_bypass only)")
-parser.add_option("--namelist_file",  dest="namelist_file", default='', \
-                  help="File containing custom namelist options for user_nl_clm")
-parser.add_option("--ilambvars", dest="ilambvars", default=False, \
-                 action="store_true", help="Write special outputs for diagnostics")
-parser.add_option("--dailyvars", dest="dailyvars", default=False, \
-                 action="store_true", help="Write daily ouptut variables")
-parser.add_option("--res", dest="res", default="CLM_USRDAT", \
-                      help='Resoultion for global simulation')
-parser.add_option("--point_list", dest="point_list", default='', \
-                  help = 'File containing list of points to run')
 parser.add_option("--pft", dest="mypft", default=-1, \
                   help = 'Use this PFT for all gridcells')
-parser.add_option("--site_forcing", dest="site_forcing", default='', \
-                  help = '6-character FLUXNET code for forcing data')
-parser.add_option("--site", dest="site", default='', \
-                  help = '6-character FLUXNET code to run (required)')
-parser.add_option("--sitegroup", dest="sitegroup", default="AmeriFlux", \
-                  help = "site group to use (default AmeriFlux)")
+parser.add_option("--parm_file", dest="parm_file", default='',
+                  help = 'file for parameter modifications')
+parser.add_option("--parm_vals", dest="parm_vals", default="", \
+                  help = 'User specified parameter values')
+parser.add_option("--parm_file_P", dest="parm_file_P", default='',
+                  help = 'file for P parameter modifications')
+
+
+# general model build options
+parser.add_option("--machine", dest="machine", default = '', \
+                  help = "machine to\n")
+parser.add_option("--compiler", dest="compiler", default='', \
+	          help = "compiler to use (pgi, gnu)")
+parser.add_option("--mpilib", dest="mpilib", default="mpi-serial", \
+                      help = "mpi library (openmpi*, mpich, ibm, mpi-serial)")
+parser.add_option("--diags", dest="diags", default=False, \
+                 action="store_true", help="Write special outputs for diagnostics")
+parser.add_option("--debugq", dest="debug", default=False, \
+                 action="store_true", help='Use debug queue')
+parser.add_option("--srcmods_loc", dest="srcmods_loc", default='', \
+                  help = 'Copy sourcemods from this location')
+
+# CASE options
 parser.add_option("--coldstart", dest="coldstart", default=False, \
                   help = "set cold start (mutually exclusive w/finidat)", \
                   action="store_true")
 parser.add_option("--compset", dest="compset", default='I1850CNPRDCTCBC', \
                   help = "component set to use (required)\n"
                          "Currently supports ONLY *CLM45(CN) compsets")
+
+
+
+
+
+parser.add_option("--istrans", dest="istrans", default=False, action="store_true",\
+                 help="Force compset to act like transient")
+parser.add_option("--lat_bounds", dest="lat_bounds", default='-999,-999', \
+                  help = 'latitude range for regional run')
+parser.add_option("--lon_bounds", dest="lon_bounds", default='-999,-999', \
+                  help = 'longitude range for regional run')
+
+parser.add_option("--humhol", dest="humhol", default=False, \
+                  help = 'Use hummock/hollow microtopography', action="store_true")
+
+parser.add_option("--mask", dest="mymask", default='', \
+                  help = 'Mask file to use (regional only)')
+
+parser.add_option("--model", dest="mymodel", default='', \
+                  help = 'Model to use (ELM,CLM5)')
+
+parser.add_option("--namelist_file",  dest="namelist_file", default='', \
+                  help="File containing custom namelist options for user_nl_clm")
+
+parser.add_option("--ilambvars", dest="ilambvars", default=False, \
+                 action="store_true", help="Write special outputs for diagnostics")
+parser.add_option("--dailyvars", dest="dailyvars", default=False, \
+                 action="store_true", help="Write daily ouptut variables")
+
+parser.add_option("--res", dest="res", default="CLM_USRDAT", \
+                      help='Resoultion for global simulation')
+parser.add_option("--point_list", dest="point_list", default='', \
+                  help = 'File containing list of points to run')
+
+
+# model input options
+parser.add_option("--sitegroup", dest="sitegroup", default="AmeriFlux", \
+                  help = "site group to use (default AmeriFlux)")
+parser.add_option("--site", dest="site", default='', \
+                  help = '6-character FLUXNET code to run (required)')
+parser.add_option("--site_forcing", dest="site_forcing", default='', \
+                  help = '6-character FLUXNET code for forcing data')
+parser.add_option("--metdir", dest="metdir", default="none", \
+                  help = 'subdirectory for met data forcing')
+
+
+# metdata
 parser.add_option("--cruncep", dest="cruncep", default=False, \
                   help = "use cru-ncep data", action="store_true")
 parser.add_option("--cruncepv8", dest="cruncepv8", default=False, \
@@ -98,22 +134,28 @@ parser.add_option("--livneh", dest="livneh", default=False, \
                   action="store_true", help = "Livneh correction to CRU precip (CONUS only)")
 parser.add_option("--daymet", dest="daymet", default=False, \
                   action="store_true", help = "Daymet correction to GSWP3 precip (CONUS only)")
-parser.add_option("--machine", dest="machine", default = '', \
-                  help = "machine to\n")
-parser.add_option("--compiler", dest="compiler", default='', \
-	          help = "compiler to use (pgi, gnu)")
-parser.add_option("--mpilib", dest="mpilib", default="mpi-serial", \
-                      help = "mpi library (openmpi*, mpich, ibm, mpi-serial)")
+parser.add_option("--monthly_metdata", dest="monthly_metdata", default = '', \
+                  help = "File containing met data (cpl_bypass only)")
+parser.add_option("--add_temperature", dest="addt", default=0.0, \
+                  help = 'Temperature to add to atmospheric forcing')
+parser.add_option("--co2_file", dest="co2_file", default="fco2_datm_rcp4.5_1765-2500_c130312.nc", \
+                  help = 'CLM timestep (hours)')
+parser.add_option("--add_co2", dest="addco2", default=0.0, \
+                  help = 'CO2 (ppmv) to add to atmospheric forcing')
+parser.add_option("--startdate_add_temperature", dest="sd_addt", default="99991231", \
+                  help = 'Date (YYYYMMDD) to begin addding temperature')
+parser.add_option("--startdate_add_co2", dest="sd_addco2", default="99991231", \
+                  help = 'Date (YYYYMMDD) to begin addding CO2')
+
+# surface data
+
+
 parser.add_option("--ad_spinup", action="store_true", \
                   dest="ad_spinup", default=False, \
                   help = 'Run accelerated decomposition spinup')
 parser.add_option("--exit_spinup", action="store_true", \
                   dest="exit_spinup", default=False, \
                   help = 'Run exit spinup (CLM 4.0 only)')
-parser.add_option("--model_root", dest="csmdir", default='', \
-                  help = "base model directory")
-parser.add_option("--ccsm_input", dest="ccsm_input", default='', \
-                  help = "input data directory for CESM (required)")
 parser.add_option("--finidat_case", dest="finidat_case", default='', \
                   help = "case containing initial data file to use" \
                   +" (should be in your run directory)")
@@ -134,20 +176,17 @@ parser.add_option("--run_startyear", dest="run_startyear",default=-1, \
 parser.add_option("--rmold", dest="rmold", default=False, action="store_true", \
                   help = 'Remove old case directory with same name' \
                   +" before proceeding")
-parser.add_option("--srcmods_loc", dest="srcmods_loc", default='', \
-                  help = 'Copy sourcemods from this location')
-parser.add_option("--parm_file", dest="parm_file", default='',
-                  help = 'file for parameter modifications')
-parser.add_option("--parm_vals", dest="parm_vals", default="", \
-                  help = 'User specified parameter values')
-parser.add_option("--parm_file_P", dest="parm_file_P", default='',
-                  help = 'file for P parameter modifications')
+
+# model output options
+parser.add_option("--dailyrunoff", dest="dailyrunoff", default=False, \
+                 action="store_true", help="Write daily output for hydrology")
 parser.add_option("--hist_mfilt", dest="hist_mfilt", default=-1, \
                   help = 'number of output timesteps per file')
 parser.add_option("--hist_nhtfrq", dest="hist_nhtfrq", default=-999, \
                   help = 'output file timestep')
 parser.add_option("--hist_vars", dest="hist_vars", default='', \
                   help = 'Output only selected variables in h0 file (comma delimited)')
+
 #parser.add_option("--queue", dest="queue", default='essg08q', \
 #                  help = 'PBS submission queue')
 parser.add_option("--clean_config", dest="clean_config", default=False, \
@@ -171,12 +210,9 @@ parser.add_option("--ng", dest="ng", default=64, \
                   help = 'number of groups to run in ensmble mode')
 parser.add_option("--tstep", dest="tstep", default=0.5, \
                   help = 'CLM timestep (hours)')
-parser.add_option("--co2_file", dest="co2_file", default="fco2_datm_rcp4.5_1765-2500_c130312.nc", \
-                  help = 'CLM timestep (hours)')
+
 parser.add_option("--nyears_ad_spinup", dest="ny_ad", default=250, \
                   help = 'number of years to run ad_spinup')
-parser.add_option("--metdir", dest="metdir", default="none", \
-                  help = 'subdirectory for met data forcing')
 parser.add_option("--nopointdata", action="store_true", \
                   dest="nopointdata", help="Do NOT make point data (use data already created)", \
                   default=False)
@@ -219,7 +255,9 @@ parser.add_option("--surfdata_grid", dest="surfdata_grid", default=False, \
 parser.add_option("--include_nonveg", dest="include_nonveg", default=False, \
                   help = 'Include non-vegetated columns/Landunits in surface data')
 parser.add_option("--trans2", dest="trans2", default=False, action="store_true", \
-                  help = 'Tranisnent phase 2 (1901-2010) - CRUNCEP only')
+                  help = 'Transient phase 2 (1901-2010) - CRUNCEP only')
+parser.add_option("--transtag", dest="transtag", default="", \
+                  help = 'Transient experiment runs, generally any tag to append to a casename')
 parser.add_option("--spinup_vars", dest="spinup_vars", default=False, \
                   help = 'Limit output vars in spinup runs', action="store_true")
 parser.add_option("--trans_varlist", dest = "trans_varlist", default='', help = "Transient outputs")
@@ -245,14 +283,6 @@ parser.add_option("--fates_nutrient", dest="fates_nutrient", default="", \
                   help = 'Which version of fates_nutrient to use (RD or ECA)')
 parser.add_option("--fates_paramfile", dest="fates_paramfile", default="", \
                   help = 'Fates parameter file to use')
-parser.add_option("--add_temperature", dest="addt", default=0.0, \
-                  help = 'Temperature to add to atmospheric forcing')
-parser.add_option("--add_co2", dest="addco2", default=0.0, \
-                  help = 'CO2 (ppmv) to add to atmospheric forcing')
-parser.add_option("--startdate_add_temperature", dest="sd_addt", default="99991231", \
-                  help = 'Date (YYYYMMDD) to begin addding temperature')
-parser.add_option("--startdate_add_co2", dest="sd_addco2", default="99991231", \
-                  help = 'Date (YYYYMMDD) to begin addding CO2')
 #Changed by Ming for mesabi
 parser.add_option("--archiveroot", dest="archiveroot", default='', \
                   help = "archive root directory only for mesabi")
@@ -472,6 +502,8 @@ if (options.exit_spinup):
     casename = casename+'_exit_spinup'
 if (options.istrans and not "20TR" in compset):
     casename = casename+'_trans'
+if (options.transtag != ""): 
+    casename = casename+'_'+options.transtag
 
 PTCLMfiledir = options.ccsm_input+'/lnd/clm2/PTCLM'
 

--- a/runcase.py
+++ b/runcase.py
@@ -21,6 +21,9 @@ from optparse import OptionParser
 
 parser = OptionParser()
 
+# general OLMT options
+
+
 parser.add_option("--caseidprefix", dest="mycaseid", default="", \
                   help="Unique identifier to include as a prefix to the case name")
 parser.add_option("--caseroot", dest="caseroot", default='', \

--- a/runcase.py
+++ b/runcase.py
@@ -1191,6 +1191,7 @@ for i in range(1,int(options.ninst)+1):
             output.write(' check_finidat_year_consistency = .false.\n')
     #pft-physiology file
     output.write(" paramfile = '"+rundir+"/clm_params.nc'\n")
+
     if ('ED' in compset and options.fates_paramfile != ''):
       output.write(" fates_paramfile = '"+options.fates_paramfile+"'\n")
     if ('ED' in compset and options.fates_hydro):
@@ -1254,6 +1255,7 @@ for i in range(1,int(options.ninst)+1):
             output.write(" nu_com = 'ECA'\n")
         elif ('RD' in options.fates_nutrient):
             output.write(" nu_com = 'RD'\n")
+
     if (cpl_bypass):
         if (use_reanalysis):
             if (options.cruncepv8):
@@ -1312,6 +1314,7 @@ for i in range(1,int(options.ninst)+1):
                 output.write(" metdata_bypass = '"+options.ccsm_input+"/atm/datm7/" \
                           +"atm_forcing.cpl.CBGC1850S.ne30.c181011/cpl_bypass_full'\n")
 #                         +"atm_forcing.cpl.WCYCL1850S.ne30.c171204/cpl_bypass_full'\n")
+        # not reanalysis
         else:
             if (options.site_forcing == ''):
               options.site_forcing=options.site
@@ -1337,13 +1340,16 @@ for i in range(1,int(options.ninst)+1):
         else:
           output.write(" aero_file = '"+options.ccsm_input+"/atm/cam/chem/" \
                          +"trop_mozart_aero/aero/aerosoldep_rcp4.5_monthly_1849-2104_1.9x2.5_c100402.nc'\n")
+
     if (options.addt != 0):
       output.write(" add_temperature = "+str(options.addt)+"\n")
       output.write(" startdate_add_temperature = '"+str(options.sd_addt)+"'\n")
+
     if (options.addco2 != 0):
       output.write(" add_co2 = "+str(options.addco2)+"\n")
       output.write(" startdate_add_co2 = '"+str(options.sd_addco2)+"'\n")
     output.close()
+
 
 #configure case
 #if (isglobal):

--- a/site_fullrun.py
+++ b/site_fullrun.py
@@ -618,7 +618,8 @@ for row in AFdatareader:
             cmd_adsp = cmd_adsp+' --exeroot '+ad_exeroot+' --no_build'
 
         if (options.cpl_bypass):
-            if (options.crop or options.fates):
+            #if (options.crop or options.fates):
+            if (options.crop):
               cmd_adsp = cmd_adsp+' --compset ICB'+mycompset_adsp
               ad_case = site+'_ICB'+mycompset_adsp
             else:
@@ -643,11 +644,13 @@ for row in AFdatareader:
         if (sitenum == 0 and options.exeroot == ''):
             ad_exeroot = os.path.abspath(runroot+'/'+ad_case+'/bld')
 
+
         #final spinup
         if mycaseid !='':
             basecase=mycaseid+'_'+site
             if (options.cpl_bypass):
-                if (options.crop or options.fates):
+                #if (options.crop or options.fates):
+                if (options.crop):
                   basecase = basecase+'_ICB'+mycompset
                 else:
                   basecase = basecase+'_ICB1850'+mycompset
@@ -657,7 +660,8 @@ for row in AFdatareader:
                 #    basecase = basecase+'_I'+mycompset
         else:
             if (options.cpl_bypass):
-                if (options.crop or options.fates):
+                #if (options.crop or options.fates):
+                if (options.crop):
                   basecase = site+'_ICB'+mycompset
                 else:
                   basecase=site+'_ICB1850'+mycompset
@@ -700,7 +704,8 @@ for row in AFdatareader:
             if (options.sp):
               cmd_fnsp = cmd_fnsp+' --compset ICBCLM45BC'
             else:
-              if (options.crop or options.fates):
+              #if (options.crop or options.fates):
+              if (options.crop):
                 cmd_fnsp = cmd_fnsp+' --compset ICB'+mycompset
               else:
                 cmd_fnsp = cmd_fnsp+' --compset ICB1850'+mycompset
@@ -716,6 +721,7 @@ for row in AFdatareader:
         if (options.ensemble_file != '' and options.notrans and options.constraints == ''):	
                 cmd_fnsp = cmd_fnsp + ' --postproc_file '+options.postproc_file
 
+
         #transient
         cmd_trns = basecmd+' --finidat_case '+basecase+ \
             ' --finidat_year '+str(fsplen+1)+' --run_units nyears' \
@@ -729,10 +735,10 @@ for row in AFdatareader:
             else:
               cmd_trns = cmd_trns+' --compset ICB20TR'+mycompset
         else:
-            if (options.fates):
-              cmd_trns = cmd_trns+' --istrans --compset I'+mycompset
-            else:
-              cmd_trns = cmd_trns+' --compset I20TR'+mycompset
+#            if (options.fates):
+#              cmd_trns = cmd_trns+' --istrans --compset I'+mycompset
+#            else:
+            cmd_trns = cmd_trns+' --compset I20TR'+mycompset
         if (options.spinup_vars):
             cmd_trns = cmd_trns + ' --spinup_vars'
         if (options.trans_varlist != ''):
@@ -744,6 +750,7 @@ for row in AFdatareader:
         if (not options.nofire):
             #Turn wildfire off in transient simulations (disturbances are known)
             cmd_trns = cmd_trns + ' --nofire'
+
 
         #transient phase 2 
         #(CRU-NCEP only, without coupler bypass)
@@ -758,28 +765,33 @@ for row in AFdatareader:
                 ' --compset I20TR'+mycompset+' --nopointdata'
             #print(cmd_trns2)
 
+
         # experimental manipulation, without coupler bypass
         # APW: check align_year is correct, 
         # APW: do we want different outputs? Maybe the full set here and a reduced set for the initial transient?
+        #elif ((options.eco2_file != '') and not options.cpl_bypass):
+        #    basecase=basecase.replace('1850','')+'_trans'
         elif ((options.eco2_file != '') and not options.cpl_bypass):
-            basecase=basecase.replace('1850','')+'_trans'
+            basecase=basecase.replace('1850','20TR')
 
             # ambient CO2 run 
-            cmd_trns2 = basecmd+' --transtag aCO2 --istrans --finidat_case '+basecase+ \
+            #cmd_trns2 = basecmd+' --transtag aCO2 --istrans --finidat_case '+basecase+ \
+            cmd_trns2 = basecmd+' --transtag aCO2 --finidat_case '+basecase+ \
                 ' --finidat_year '+str(startyear)+' --run_units nyears --branch ' \
                 +' --run_n '+str(ncycle)+' --align_year '+str(startyear)+ \
                 ' --hist_nhtfrq '+options.hist_nhtfrq+' --hist_mfilt '+ \
                 options.hist_mfilt+' --no_build'+' --exeroot '+ad_exeroot + \
-                ' --compset I'+mycompset+' --nopointdata'
+                ' --compset I20TR'+mycompset+' --nopointdata'
           
             # elevated CO2 run 
             basecmd_eco2=basecmd.replace(options.co2_file,options.eco2_file)
-            cmd_trns3 = basecmd+' --transtag eCO2 --istrans --finidat_case '+basecase+ \
+            #cmd_trns3 = basecmd+' --transtag eCO2 --istrans --finidat_case '+basecase+ \
+            cmd_trns3 = basecmd+' --transtag eCO2 --finidat_case '+basecase+ \
                 ' --finidat_year '+str(startyear)+' --run_units nyears --branch ' \
                 +' --run_n '+str(ncycle)+' --align_year '+str(startyear)+ \
                 ' --hist_nhtfrq '+options.hist_nhtfrq+' --hist_mfilt '+ \
                 options.hist_mfilt+' --no_build'+' --exeroot '+ad_exeroot + \
-                ' --compset I'+mycompset+' --nopointdata'
+                ' --compset I20TR'+mycompset+' --nopointdata'
           
 
 #---------------------------------------------------------------------------------
@@ -853,7 +865,8 @@ for row in AFdatareader:
         if (options.notrans == False):
             print('\n\nSetting up transient case\n')
             if (sitenum == 0):
-                if (options.crop or options.fates):
+                #if (options.crop or options.fates):
+                if (options.crop):
                   tr_case_firstsite = fin_case_firstsite+'_trans'
                 else:
                   tr_case_firstsite = fin_case_firstsite.replace('1850','20TR')
@@ -887,7 +900,7 @@ for row in AFdatareader:
                 if (result > 0):
                     print('Site_fullrun:  Error in runcase.py for transient 2')
                     sys.exit(1)
-                print('\nSetting up experiemnt transient case 3\n')
+                print('\n\nSetting up experiemnt transient case 3\n')
                 print(cmd_trns3)
                 result = os.system(cmd_trns3)
                 if (result > 0):
@@ -1015,11 +1028,11 @@ for row in AFdatareader:
                   modelst = 'ICBCLM45BC'
                 if (options.crop):
                   modelst = 'ICBCLM45CNCROP'
-                if (options.fates):
-                  modelst = 'ICBCLM45ED'
-            else:
-                if (options.fates):
-                    modelst = 'I1850CLM45ED'
+#                if (options.fates):
+#                  modelst = 'ICB1850CLM45ED'
+#            else:
+#                if (options.fates):
+#                    modelst = 'I1850CLM45ED'
 
             basecase = site
             if (mycaseid != ''):
@@ -1083,16 +1096,16 @@ for row in AFdatareader:
             if (sitenum == 0 and 'transient' in c):
                 if (options.crop):
                   output.write("cd "+caseroot+'/'+basecase+"_"+modelst+"_trans\n")
-                elif (options.fates):
-                  output.write("cd "+caseroot+'/'+basecase+"_"+modelst.replace('1850','')+"_trans\n")
+#                elif (options.fates):
+#                  output.write("cd "+caseroot+'/'+basecase+"_"+modelst.replace('1850','')+"_trans\n")
                 else:
                   output.write("cd "+caseroot+'/'+basecase+"_"+modelst.replace('1850','20TR')+"\n")
                 output.write('./case.submit --no-batch &\n')
             elif ('transient' in c):
                 if (options.crop):
                   output.write("cd "+runroot+'/'+basecase+"_"+modelst+"_trans/run\n")
-                elif (options.fates):
-                  output.write("cd "+runroot+'/'+basecase+"_"+modelst.replace('1850','')+"_trans/run\n")
+#                elif (options.fates):
+#                  output.write("cd "+runroot+'/'+basecase+"_"+modelst.replace('1850','')+"_trans/run\n")
                 else:
                   output.write("cd "+runroot+'/'+basecase+"_"+modelst.replace('1850','20TR')+"/run\n")
 
@@ -1108,9 +1121,9 @@ for row in AFdatareader:
 
                 if (options.crop):
                   output.write("cd "+simroot+'/'+basecase+"_"+modelst+"_"+c+"/run\n")
-                elif (options.fates):
-                  #output.write("cd "+simroot+'/'+basecase+"_"+modelst.replace('1850','')+"_"+c+"/run\n")
-                  output.write("cd "+simroot+'/'+basecase+"_"+modelst.replace('1850','')+"_"+c+"\n")
+#                elif (options.fates):
+#                  #output.write("cd "+simroot+'/'+basecase+"_"+modelst.replace('1850','')+"_"+c+"/run\n")
+#                  output.write("cd "+simroot+'/'+basecase+"_"+modelst.replace('1850','')+"_"+c+"\n")
                 else:
                   output.write("cd "+simroot+'/'+basecase+"_"+modelst.replace('1850','20TR')+c.replace('trans_','')+"/run\n")
                 output.write(line2) 
@@ -1173,14 +1186,16 @@ for row in AFdatareader:
                     cases.append(basecase+'_'+modelst.replace('CNP','CN')+'_ad_spinup')
             cases.append(basecase+'_'+modelst)
             if (options.notrans == False):
-                if (options.crop or options.fates):
+                #if (options.crop or options.fates):
+                if (options.crop):
                   cases.append(basecase+'_'+modelst+'_trans')
                 else:
                   cases.append(basecase+'_'+modelst.replace('1850','20TR'))
             job_depend_run=''    
             if (len(cases) > 1 and options.constraints != ''):
               cases=[]    #QPSO will run all cases
-              if (options.crop or options.fates):
+              #if (options.crop or options.fates):
+              if (options.crop):
                 cases.append(basecase+'_'+modelst+'_trans')
               else:
                 cases.append(basecase+'_'+modelst.replace('1850','20TR'))

--- a/site_fullrun.py
+++ b/site_fullrun.py
@@ -83,9 +83,9 @@ parser.add_option("--site", dest="site", default='', \
                   help = '6-character FLUXNET code to run (required)')
 parser.add_option("--sitegroup", dest="sitegroup",default="AmeriFlux", \
                   help = "site group to use (default AmeriFlux)")
-# metdata 
 parser.add_option("--ccsm_input", dest="ccsm_input", default='', \
                   help = "input data directory for CESM (required)")
+# metdata 
 parser.add_option("--nopointdata", dest="nopointdata", default=False, action="store_true", \
                   help="Do NOT make point data (use data already created)")
 parser.add_option("--metdir", dest="metdir", default="none", \
@@ -241,6 +241,7 @@ elif (not os.path.exists(options.csmdir)):
 npernode=32
 if (options.machine == ''):
    hostname = socket.gethostname()
+   print('')
    print('Machine not specified.  Using hostname '+hostname+' to determine machine')
    if ('or-condo' in hostname):
        options.machine = 'cades'

--- a/site_fullrun.py
+++ b/site_fullrun.py
@@ -566,41 +566,57 @@ for row in AFdatareader:
 
 #---------------- build commands for runcase.py -----------------------------
 
-        #ECA or CTC
+        # define compsets
+        # C, CN, CNP
         if (options.c_only):
             nutrients = 'C'
         elif (options.cn_only):
             nutrients = 'CN'
         else: 
             nutrients = 'CNP'
+        
+        # CENTURY or CTC
         if (options.centbgc):
             decomp_model = 'CNT'
         else:
             decomp_model = 'CTC'
+
+        # ECA or RD 
         if (options.eca):
             mycompset = nutrients+'ECA'+decomp_model
+        # APW: seems redundant given if statement below 
         elif (options.fates):
             mycompset = 'CLM45ED'
         else:
             mycompset = nutrients+'RD'+decomp_model+'BC'
 
+        # add P during initial spinup
         if (not options.ad_Pinit):
             mycompset_adsp = mycompset.replace('CNP','CN')
         else:
             mycompset_adsp = mycompset
+        
+        # crop model 
         if (options.crop):
             mycompset = 'CLM45CNCROP'
             mycompset_adsp = mycompset   
+        
+        # FATES model 
         if (options.fates):
             mycompset = 'CLM45ED'
             mycompset_adsp = mycompset
+        
+        # model executable E3SM / CESM 
         myexe = 'e3sm.exe'
         if ('clm5' in options.csmdir):
             mycompset = 'Clm50BgcGs'
             mycompset_adsp = 'Clm50BgcGs'
             myexe = 'cesm.exe'
 
-        #AD spinup
+
+        # develop calls to runcase.py
+
+        # AD spinup
         cmd_adsp = basecmd+' --ad_spinup --nyears_ad_spinup '+ \
             str(ny_ad)+' --align_year '+str(year_align+1)
         if (int(options.hist_mfilt_spinup) == -999):
@@ -622,7 +638,6 @@ for row in AFdatareader:
             cmd_adsp = cmd_adsp+' --exeroot '+ad_exeroot+' --no_build'
 
         if (options.cpl_bypass):
-            #if (options.crop or options.fates):
             if (options.crop):
               cmd_adsp = cmd_adsp+' --compset ICB'+mycompset_adsp
               ad_case = site+'_ICB'+mycompset_adsp
@@ -634,9 +649,7 @@ for row in AFdatareader:
         else:
             cmd_adsp = cmd_adsp+' --compset I1850'+mycompset_adsp
             ad_case = site+'_I1850'+mycompset_adsp
-            #if (options.fates):
-            #    cmd_adsp = cmd_adsp+' --compset I'+mycompset_adsp
-            #    ad_case = site+'_I'+mycompset_adsp
+
         if (options.noad == False):
             ad_case = ad_case+'_ad_spinup'
         if (options.makemet):
@@ -649,32 +662,27 @@ for row in AFdatareader:
             ad_exeroot = os.path.abspath(runroot+'/'+ad_case+'/bld')
 
 
-        #final spinup
+        # final spinup
         if mycaseid !='':
             basecase=mycaseid+'_'+site
             if (options.cpl_bypass):
-                #if (options.crop or options.fates):
                 if (options.crop):
                   basecase = basecase+'_ICB'+mycompset
                 else:
                   basecase = basecase+'_ICB1850'+mycompset
             else: 
                 basecase = basecase+'_I1850'+mycompset
-                #if (options.fates):
-                #    basecase = basecase+'_I'+mycompset
         else:
             if (options.cpl_bypass):
-                #if (options.crop or options.fates):
                 if (options.crop):
                   basecase = site+'_ICB'+mycompset
                 else:
                   basecase=site+'_ICB1850'+mycompset
             else:
                 basecase=site+'_I1850'+mycompset
-                #if (options.fates):
-                #    basecase = basecase+'_I'+mycompset
             if (options.sp):
                 basecase=site+'_ICBCLM45BC'
+
         if (options.noad):
             cmd_fnsp = basecmd+' --run_units nyears --run_n '+str(fsplen)+' --align_year '+ \
                        str(year_align+1)+' --coldstart'
@@ -695,6 +703,7 @@ for row in AFdatareader:
                        ' --finidat_year '+str(int(ny_ad)+1)+' --run_units nyears --run_n '+ \
                        str(fsplen)+' --align_year '+str(year_align+1)+' --no_build' + \
                        ' --exeroot '+ad_exeroot+' --nopointdata'
+
         if (int(options.hist_mfilt_spinup) == -999):
             if (options.sp):
               cmd_fnsp = cmd_fnsp+' --hist_mfilt 365 --hist_nhtfrq -24'
@@ -704,19 +713,17 @@ for row in AFdatareader:
         else:
             cmd_fnsp = cmd_fnsp+' --hist_mfilt '+str(options.hist_mfilt_spinup) \
                    +' --hist_nhtfrq '+str(options.hist_nhtfrq_spinup)
+
         if (options.cpl_bypass):
             if (options.sp):
               cmd_fnsp = cmd_fnsp+' --compset ICBCLM45BC'
             else:
-              #if (options.crop or options.fates):
               if (options.crop):
                 cmd_fnsp = cmd_fnsp+' --compset ICB'+mycompset
               else:
                 cmd_fnsp = cmd_fnsp+' --compset ICB1850'+mycompset
         else:
             cmd_fnsp = cmd_fnsp+' --compset I1850'+mycompset
-            #if (options.fates):
-            #    cmd_fnsp = cmd_fnsp+' --compset I'+mycompset
 
         if (options.spinup_vars):
                 cmd_fnsp = cmd_fnsp+' --spinup_vars'
@@ -733,16 +740,15 @@ for row in AFdatareader:
             str(year_align+1850)+' --hist_nhtfrq '+ \
             options.hist_nhtfrq+' --hist_mfilt '+options.hist_mfilt+' --no_build' + \
             ' --exeroot '+ad_exeroot+' --nopointdata'
+        
         if (options.cpl_bypass):
             if (options.crop or options.fates):
               cmd_trns = cmd_trns+' --istrans --compset ICB'+mycompset
             else:
               cmd_trns = cmd_trns+' --compset ICB20TR'+mycompset
         else:
-#            if (options.fates):
-#              cmd_trns = cmd_trns+' --istrans --compset I'+mycompset
-#            else:
             cmd_trns = cmd_trns+' --compset I20TR'+mycompset
+        
         if (options.spinup_vars):
             cmd_trns = cmd_trns + ' --spinup_vars'
         if (options.trans_varlist != ''):
@@ -770,16 +776,13 @@ for row in AFdatareader:
             #print(cmd_trns2)
 
 
-        # experimental manipulation, without coupler bypass
+        # experimental manipulation transients, without coupler bypass
         # APW: check align_year is correct, 
         # APW: do we want different outputs? Maybe the full set here and a reduced set for the initial transient?
-        #elif ((options.eco2_file != '') and not options.cpl_bypass):
-        #    basecase=basecase.replace('1850','')+'_trans'
         elif ((options.eco2_file != '') and not options.cpl_bypass):
             basecase=basecase.replace('1850','20TR')
 
             # ambient CO2 run 
-            #cmd_trns2 = basecmd+' --transtag aCO2 --istrans --finidat_case '+basecase+ \
             cmd_trns2 = basecmd+' --transtag aCO2 --finidat_case '+basecase+ \
                 ' --finidat_year '+str(startyear)+' --run_startyear '+str(startyear)+' --run_units nyears ' \
                 +' --run_n '+str(ncycle)+' --align_year '+str(startyear)+ \
@@ -789,7 +792,6 @@ for row in AFdatareader:
           
             # elevated CO2 run 
             basecmd_eco2=basecmd.replace(options.co2_file,options.eco2_file)
-            #cmd_trns3 = basecmd+' --transtag eCO2 --istrans --finidat_case '+basecase+ \
             cmd_trns3 = basecmd_eco2+' --transtag eCO2 --finidat_case '+basecase+ \
                 ' --finidat_year '+str(startyear)+' --run_startyear '+str(startyear)+' --run_units nyears ' \
                 +' --run_n '+str(ncycle)+' --align_year '+str(startyear)+ \
@@ -876,7 +878,6 @@ for row in AFdatareader:
         if (options.notrans == False):
             print('\n\nSetting up transient case\n')
             if (sitenum == 0):
-                #if (options.crop or options.fates):
                 if (options.crop):
                   tr_case_firstsite = fin_case_firstsite+'_trans'
                 else:
@@ -920,6 +921,7 @@ for row in AFdatareader:
 
                  
         # Create .pbs etc scripts for each case
+        # build vector of case aliases 
         case_list = []
         if (options.noad == False):
             case_list.append('ad_spinup')
@@ -930,7 +932,6 @@ for row in AFdatareader:
         if (options.diags):
             case_list.append('spinup_diags')
         if (options.notrans == False):
-            # APW TCOFD
             case_list.append('transient')
             if (options.eco2_file):
                 case_list.append('trans_aCO2')
@@ -1034,7 +1035,8 @@ for row in AFdatareader:
                     output.write('module load python/2.7.12\n')
             else:
                 output = open('./scripts/'+myscriptsdir+'/'+c+'_group'+str(groupnum)+'.pbs','a')   
-                
+               
+            # build full spin compset for writing to submit scripts
             modelst = 'I1850'+mycompset
             if (options.cpl_bypass):
                 modelst = 'ICB1850'+mycompset
@@ -1042,26 +1044,16 @@ for row in AFdatareader:
                   modelst = 'ICBCLM45BC'
                 if (options.crop):
                   modelst = 'ICBCLM45CNCROP'
-#                if (options.fates):
-#                  modelst = 'ICB1850CLM45ED'
-#            else:
-#                if (options.fates):
-#                    modelst = 'I1850CLM45ED'
 
             basecase = site
             if (mycaseid != ''):
                 basecase = mycaseid+'_'+site
 
             if (sitenum == 0 and 'ad_spinup' in c):
-            #if ('ad_spinup' in c):
                 if (options.ad_Pinit):
                     output.write("cd "+caseroot+'/'+basecase+"_"+modelst+"_ad_spinup/\n")
                 else:
                     output.write("cd "+caseroot+'/'+basecase+"_"+modelst.replace('CNP','CN')+"_ad_spinup/\n")
-                #if (sitenum == 0):
-                #    output.write("./case.submit --no-batch &\n")
-                #else:
-                #    output.write(runroot+'/'+ad_case_firstsite+'/bld/'+myexe+' &\n')
                 output.write("./case.submit --no-batch &\n")
             elif ('ad_spinup' in c):
                 if (options.ad_Pinit):
@@ -1122,9 +1114,9 @@ for row in AFdatareader:
 #                  output.write("cd "+runroot+'/'+basecase+"_"+modelst.replace('1850','')+"_trans/run\n")
                 else:
                   output.write("cd "+runroot+'/'+basecase+"_"+modelst.replace('1850','20TR')+"/run\n")
-
                 output.write(runroot+'/'+ad_case_firstsite+'/bld/'+myexe+' &\n')
 
+            # APW: possible alternative structure for these if statements, could help simplfy
             elif ('trans_' in c and c != 'trans_diags'):
                 if (sitenum == 0):
                     simroot=caseroot
@@ -1134,19 +1126,11 @@ for row in AFdatareader:
                     simroot=runroot
                     simsuffix='/run'
                     simsubmit=runroot+'/'+ad_case_firstsite+'/bld/'+myexe+' &\n'
-
                 if (options.crop):
                   output.write("cd "+simroot+'/'+basecase+"_"+modelst+"_"+c+simsuffix+"\n")
-#                elif (options.fates):
-#                  #output.write("cd "+simroot+'/'+basecase+"_"+modelst.replace('1850','')+"_"+c+"/run\n")
-#                  output.write("cd "+simroot+'/'+basecase+"_"+modelst.replace('1850','')+"_"+c+"\n")
                 else:
                   output.write("cd "+simroot+'/'+basecase+"_"+modelst.replace('1850','20TR')+c.replace('trans','')+simsuffix+"\n")
                 output.write(simsubmit) 
-#                if (sitenum == 0):
-#                    output.write('./case.submit --no-batch &\n')
-#                else: 
-#                    output.write(runroot+'/'+ad_case_firstsite+'/bld/'+myexe+' &\n')
 
             if ('trans_diags' in c):
                  if (options.cpl_bypass):
@@ -1187,10 +1171,10 @@ for row in AFdatareader:
             output.close()
 
 
+#sys.exit('temp stop pre-submit')
 # submit jobs created by runcase.py 
 #======================================================#
 
-        #sys.exit('temp stop pre-submit')
         #if ensemble simulations requested, submit jobs created by runcase.py in correct order
         if (options.ensemble_file != ''):
             cases=[]
@@ -1226,7 +1210,8 @@ for row in AFdatareader:
         #    job_fullrun = submit('temp/site_fullrun.pbs', submit_type=mysubmit_type)
         sitenum = sitenum+1
 
-# Submit PBS scripts for multi-site simulations on 1 node
+
+# Submit PBS scripts for single/multi-site simulations on 1 node
 if (options.ensemble_file == ''):
     for g in range(0,int(groupnum)+1):
         job_depend_run=''


### PR DESCRIPTION
This PR includes options for 2 additional transient simulations. Currently those are aCO2 and eCO2 to represent FACE or other CO2 experiments. This also fixes various issues with selection of FATES combined with a request for transient simulations, which uses the I20TR... type compset -- requires modification to E3SM code.

These edits have not been extensively tested at all. The only test they have received is that the code is building and the various cases running and producing output. I've not looked at that output yet. The reason I made this PR now is because I know you're actively working on OLMT as well @dmricciuto and I think it'd be good for us to try to keep our edits integrated and not duplicate effort.      


## I20TR compset
This PR now allows FATES to run with the I20TR compset, and removes the '_trans'  label from the long case id/name for transient simulations with FATES. For FATES transient simulations the following needs to be added to E3SM code in file `E3SM/components/clm/cime_config/config_compsets.xml` around line 657: 
```   
  <compset>
    <alias>I20TRCLM45ED</alias>
    <lname>20TR_DATM%QIA_CLM45%BGC-FATES_SICE_SOCN_MOSART_SGLC_SWAV</lname>
  </compset>

```
This 20TR_DATM compset component works with OLMT. Using the compset alias `ICLM45ED` requests the 2000_DATM compset component  which was giving me trouble with the datm_in namelist and datm.streams files as is was misnaming the files associated with the aerosol input dataset.

     
## 2 experiment transients
The two experiment transients are requested when the `--eco2_file` argument to `site_fullrun.py` is not blank. The value of this argument should be the name of the elevated co2 treatment file that is of the same format as the standard transient CO2 file. This argument is designed not to work with the coupler bypass at this stage. The only transient compset it will work with for now is the I20TR. 

Selection of the experiment transient simulation will automatically end the first transient case in the year prior to the initial year of the met data. Then two further transient cases will be run each covering a single met cycle, one with ambient CO2 from the standard CO2 file (specified by argument `--co2_file`) and one with the elevated CO2 file. These transient cases will be labelled the same as the initial transient simulation with the suffixes `_aCO2` and `_eCO2`. 
     
