### PR TITLE
Update precip scaling, add ndep/pdep scaling options for OLMT

### DIFF
--- a/runcase.py
+++ b/runcase.py
@@ -263,6 +263,10 @@ parser.add_option("--1850_ndep", dest="ndep1850", default=False, \
                   help = 'Use constant 1850 N deposition', action="store_true")
 parser.add_option("--ndep_rcp85", dest="ndeprcp85", default=False, \
                   help = 'Use RCP8.5 N deposition', action="store_true")
+parser.add_option("--scale_ndep", dest="scln", default="", \
+                  help = 'Scaling factor to apply to N deposition in atmospheric forcing')
+parser.add_option("--startdate_scale_ndep", dest="sd_scln", default="99991231", \
+                  help = 'Date (YYYYMMDD) to begin scaling N deposition')                  
 parser.add_option("--1850_aero", dest="aero1850", default=False, \
                   help = 'Use constant 1850 aerosol deposition', action="store_true")
 parser.add_option("--aero_rcp85", dest="aerorcp85", default=False, \
@@ -1460,6 +1464,9 @@ for i in range(1,int(options.ninst)+1):
         else:
           output.write( " stream_fldfilename_ndep = '"+options.ccsm_input+ \
             "/lnd/clm2/ndepdata/fndep_clm_rcp4.5_simyr1849-2106_1.9x2.5_c100428.nc'\n")
+        if (options.scale_ndep != ''):
+          output.write(" scale_ndep = "+str(options.ndep)+"\n")
+          output.write(" startdate_scale_ndep = '"+str(options.sd_ndep)+"'\n")
         if (model_name == 'clm2'):  #set for older tags/branches (option was removed, this may not capture all tags 
                                     #between rename to elm and removal of nitrif_dentrif)   
             output.write(" use_nitrif_denitrif = .true.\n")

--- a/runcase.py
+++ b/runcase.py
@@ -149,9 +149,9 @@ parser.add_option("--monthly_metdata", dest="monthly_metdata", default = '', \
                   help = "File containing met data (cpl_bypass only)")
 parser.add_option("--add_temperature", dest="addt", default=0.0, \
                   help = 'Temperature to add to atmospheric forcing')
-parser.add_option("--scale_rain", dest="sclr", default=1.0, \
+parser.add_option("--scale_rain", dest="sclr", default='', \
                   help = 'Scaling factor to apply to rain in atmospheric forcing')
-parser.add_option("--scale_snow", dest="scls", default=1.0, \
+parser.add_option("--scale_snow", dest="scls", default='', \
                   help = 'Scaling factor to apply to snowfall in atmospheric forcing')
 parser.add_option("--co2_file", dest="co2_file", default="fco2_datm_rcp4.5_1765-2500_c130312.nc", \
                   help = 'CLM timestep (hours)')
@@ -1619,11 +1619,11 @@ for i in range(1,int(options.ninst)+1):
       output.write(" add_temperature = "+str(options.addt)+"\n")
       output.write(" startdate_add_temperature = '"+str(options.sd_addt)+"'\n")
 
-    if (options.sclr != 0):
+    if (options.sclr != ''):
       output.write(" scale_rain = "+str(options.sclr)+"\n")
       output.write(" startdate_scale_rain = '"+str(options.sd_sclr)+"'\n")
 
-    if (options.scls != 0):
+    if (options.scls != ''):
       output.write(" scale_snow = "+str(options.scls)+"\n")
       output.write(" startdate_scale_snow = '"+str(options.sd_scls)+"'\n")
     

--- a/runcase.py
+++ b/runcase.py
@@ -1493,8 +1493,8 @@ for i in range(1,int(options.ninst)+1):
           output.write( " stream_fldfilename_ndep = '"+options.ccsm_input+ \
             "/lnd/clm2/ndepdata/fndep_clm_rcp4.5_simyr1849-2106_1.9x2.5_c100428.nc'\n")
         if (options.scale_ndep != ''):
-          output.write(" scale_ndep = "+str(options.ndep)+"\n")
-          output.write(" startdate_scale_ndep = '"+str(options.sd_ndep)+"'\n")
+          output.write(" scale_ndep = "+str(options.scln)+"\n")
+          output.write(" startdate_scale_ndep = '"+str(options.sd_scln)+"'\n")
         if (model_name == 'clm2'):  #set for older tags/branches (option was removed, this may not capture all tags 
                                     #between rename to elm and removal of nitrif_dentrif)   
             output.write(" use_nitrif_denitrif = .true.\n")

--- a/runcase.py
+++ b/runcase.py
@@ -1621,11 +1621,11 @@ for i in range(1,int(options.ninst)+1):
 
     if (options.sclr != 0):
       output.write(" scale_rain = "+str(options.sclr)+"\n")
-      output.write(" startdate_add_rain = '"+str(options.sd_sclr)+"'\n")
+      output.write(" startdate_scale_rain = '"+str(options.sd_sclr)+"'\n")
 
     if (options.scls != 0):
       output.write(" scale_snow = "+str(options.scls)+"\n")
-      output.write(" startdate_add_snow = '"+str(options.sd_scls)+"'\n")
+      output.write(" startdate_scale_snow = '"+str(options.sd_scls)+"'\n")
     
     if (options.addco2 != 0):
       output.write(" add_co2 = "+str(options.addco2)+"\n")

--- a/runcase.py
+++ b/runcase.py
@@ -265,6 +265,10 @@ parser.add_option("--1850_ndep", dest="ndep1850", default=False, \
                   help = 'Use constant 1850 N deposition', action="store_true")
 parser.add_option("--ndep_rcp85", dest="ndeprcp85", default=False, \
                   help = 'Use RCP8.5 N deposition', action="store_true")
+parser.add_option("--scale_ndep", dest="scln", default="", \
+                  help = 'Scaling factor to apply to N deposition in atmospheric forcing')
+parser.add_option("--startdate_scale_ndep", dest="sd_scln", default="99991231", \
+                  help = 'Date (YYYYMMDD) to begin scaling N deposition')                  
 parser.add_option("--1850_aero", dest="aero1850", default=False, \
                   help = 'Use constant 1850 aerosol deposition', action="store_true")
 parser.add_option("--aero_rcp85", dest="aerorcp85", default=False, \
@@ -1488,6 +1492,9 @@ for i in range(1,int(options.ninst)+1):
         else:
           output.write( " stream_fldfilename_ndep = '"+options.ccsm_input+ \
             "/lnd/clm2/ndepdata/fndep_clm_rcp4.5_simyr1849-2106_1.9x2.5_c100428.nc'\n")
+        if (options.scale_ndep != ''):
+          output.write(" scale_ndep = "+str(options.ndep)+"\n")
+          output.write(" startdate_scale_ndep = '"+str(options.sd_ndep)+"'\n")
         if (model_name == 'clm2'):  #set for older tags/branches (option was removed, this may not capture all tags 
                                     #between rename to elm and removal of nitrif_dentrif)   
             output.write(" use_nitrif_denitrif = .true.\n")

--- a/runcase.py
+++ b/runcase.py
@@ -149,12 +149,24 @@ parser.add_option("--monthly_metdata", dest="monthly_metdata", default = '', \
                   help = "File containing met data (cpl_bypass only)")
 parser.add_option("--add_temperature", dest="addt", default=0.0, \
                   help = 'Temperature to add to atmospheric forcing')
+parser.add_option("--scale_precipitation", dest="sclp", default=1.0, \
+                  help = 'Scaling factor to apply to total precipitation in atmospheric forcing')
+parser.add_option("--scale_rain", dest="sclr", default=1.0, \
+                  help = 'Scaling factor to apply to rain in atmospheric forcing')
+parser.add_option("--scale_snow", dest="scls", default=1.0, \
+                  help = 'Scaling factor to apply to snowfall in atmospheric forcing')
 parser.add_option("--co2_file", dest="co2_file", default="fco2_datm_rcp4.5_1765-2500_c130312.nc", \
                   help = 'CLM timestep (hours)')
 parser.add_option("--add_co2", dest="addco2", default=0.0, \
                   help = 'CO2 (ppmv) to add to atmospheric forcing')
 parser.add_option("--startdate_add_temperature", dest="sd_addt", default="99991231", \
                   help = 'Date (YYYYMMDD) to begin addding temperature')
+parser.add_option("--startdate_scale_precipitation", dest="sd_sclp", default="99991231", \
+                  help = 'Date (YYYYMMDD) to begin scaling total precipitation')
+parser.add_option("--startdate_scale_rain", dest="sd_sclr", default="99991231", \
+                  help = 'Date (YYYYMMDD) to begin scaling rain')
+parser.add_option("--startdate_scale_snow", dest="sd_scls", default="99991231", \
+                  help = 'Date (YYYYMMDD) to begin scaling snowfall')
 parser.add_option("--startdate_add_co2", dest="sd_addco2", default="99991231", \
                   help = 'Date (YYYYMMDD) to begin addding CO2')
 
@@ -1611,6 +1623,18 @@ for i in range(1,int(options.ninst)+1):
       output.write(" add_temperature = "+str(options.addt)+"\n")
       output.write(" startdate_add_temperature = '"+str(options.sd_addt)+"'\n")
 
+    if (options.sclp != 0):
+      output.write(" scale_precipitation = "+str(options.sclp)+"\n")
+      output.write(" startdate_add_precipitation = '"+str(options.sd_sclp)+"'\n")
+
+    if (options.sclr != 0):
+      output.write(" scale_rain = "+str(options.sclr)+"\n")
+      output.write(" startdate_add_rain = '"+str(options.sd_sclr)+"'\n")
+
+    if (options.scls != 0):
+      output.write(" scale_snow = "+str(options.scls)+"\n")
+      output.write(" startdate_add_snow = '"+str(options.sd_scls)+"'\n")
+    
     if (options.addco2 != 0):
       output.write(" add_co2 = "+str(options.addco2)+"\n")
       output.write(" startdate_add_co2 = '"+str(options.sd_addco2)+"'\n")

--- a/runcase.py
+++ b/runcase.py
@@ -1492,9 +1492,9 @@ for i in range(1,int(options.ninst)+1):
         else:
           output.write( " stream_fldfilename_ndep = '"+options.ccsm_input+ \
             "/lnd/clm2/ndepdata/fndep_clm_rcp4.5_simyr1849-2106_1.9x2.5_c100428.nc'\n")
-        if (options.scale_ndep != ''):
-          output.write(" scale_ndep = "+str(options.ndep)+"\n")
-          output.write(" startdate_scale_ndep = '"+str(options.sd_ndep)+"'\n")
+        if (options.scln != ''):
+          output.write(" scale_ndep = "+str(options.scln)+"\n")
+          output.write(" startdate_scale_ndep = '"+str(options.sd_scln)+"'\n")
         if (model_name == 'clm2'):  #set for older tags/branches (option was removed, this may not capture all tags 
                                     #between rename to elm and removal of nitrif_dentrif)   
             output.write(" use_nitrif_denitrif = .true.\n")

--- a/runcase.py
+++ b/runcase.py
@@ -268,7 +268,11 @@ parser.add_option("--ndep_rcp85", dest="ndeprcp85", default=False, \
 parser.add_option("--scale_ndep", dest="scln", default="", \
                   help = 'Scaling factor to apply to N deposition in atmospheric forcing')
 parser.add_option("--startdate_scale_ndep", dest="sd_scln", default="99991231", \
-                  help = 'Date (YYYYMMDD) to begin scaling N deposition')                  
+                  help = 'Date (YYYYMMDD) to begin scaling N deposition')    
+parser.add_option("--scale_pdep", dest="sclp", default="", \
+                  help = 'Scaling factor to apply to P deposition in atmospheric forcing')
+parser.add_option("--startdate_scale_pdep", dest="sd_sclp", default="99991231", \
+                  help = 'Date (YYYYMMDD) to begin scaling P deposition')                   
 parser.add_option("--1850_aero", dest="aero1850", default=False, \
                   help = 'Use constant 1850 aerosol deposition', action="store_true")
 parser.add_option("--aero_rcp85", dest="aerorcp85", default=False, \
@@ -1492,9 +1496,6 @@ for i in range(1,int(options.ninst)+1):
         else:
           output.write( " stream_fldfilename_ndep = '"+options.ccsm_input+ \
             "/lnd/clm2/ndepdata/fndep_clm_rcp4.5_simyr1849-2106_1.9x2.5_c100428.nc'\n")
-        if (options.scln != ''):
-          output.write(" scale_ndep = "+str(options.scln)+"\n")
-          output.write(" startdate_scale_ndep = '"+str(options.sd_scln)+"'\n")
         if (model_name == 'clm2'):  #set for older tags/branches (option was removed, this may not capture all tags 
                                     #between rename to elm and removal of nitrif_dentrif)   
             output.write(" use_nitrif_denitrif = .true.\n")
@@ -1661,7 +1662,15 @@ for i in range(1,int(options.ninst)+1):
     if (options.scls != ''):
       output.write(" scale_snow = "+str(options.scls)+"\n")
       output.write(" startdate_scale_snow = '"+str(options.sd_scls)+"'\n")
-    
+
+    if (options.scln != ''):
+      output.write(" scale_ndep = "+str(options.scln)+"\n")
+      output.write(" startdate_scale_ndep = '"+str(options.sd_scln)+"'\n")
+
+    if (options.sclp != ''):
+      output.write(" scale_pdep = "+str(options.sclp)+"\n")
+      output.write(" startdate_scale_pdep = '"+str(options.sd_sclp)+"'\n")
+
     if (options.addco2 != 0):
       output.write(" add_co2 = "+str(options.addco2)+"\n")
       output.write(" startdate_add_co2 = '"+str(options.sd_addco2)+"'\n")

--- a/runcase.py
+++ b/runcase.py
@@ -149,8 +149,6 @@ parser.add_option("--monthly_metdata", dest="monthly_metdata", default = '', \
                   help = "File containing met data (cpl_bypass only)")
 parser.add_option("--add_temperature", dest="addt", default=0.0, \
                   help = 'Temperature to add to atmospheric forcing')
-parser.add_option("--scale_precipitation", dest="sclp", default=1.0, \
-                  help = 'Scaling factor to apply to total precipitation in atmospheric forcing')
 parser.add_option("--scale_rain", dest="sclr", default=1.0, \
                   help = 'Scaling factor to apply to rain in atmospheric forcing')
 parser.add_option("--scale_snow", dest="scls", default=1.0, \
@@ -161,8 +159,6 @@ parser.add_option("--add_co2", dest="addco2", default=0.0, \
                   help = 'CO2 (ppmv) to add to atmospheric forcing')
 parser.add_option("--startdate_add_temperature", dest="sd_addt", default="99991231", \
                   help = 'Date (YYYYMMDD) to begin addding temperature')
-parser.add_option("--startdate_scale_precipitation", dest="sd_sclp", default="99991231", \
-                  help = 'Date (YYYYMMDD) to begin scaling total precipitation')
 parser.add_option("--startdate_scale_rain", dest="sd_sclr", default="99991231", \
                   help = 'Date (YYYYMMDD) to begin scaling rain')
 parser.add_option("--startdate_scale_snow", dest="sd_scls", default="99991231", \
@@ -1622,10 +1618,6 @@ for i in range(1,int(options.ninst)+1):
     if (options.addt != 0):
       output.write(" add_temperature = "+str(options.addt)+"\n")
       output.write(" startdate_add_temperature = '"+str(options.sd_addt)+"'\n")
-
-    if (options.sclp != 0):
-      output.write(" scale_precipitation = "+str(options.sclp)+"\n")
-      output.write(" startdate_add_precipitation = '"+str(options.sd_sclp)+"'\n")
 
     if (options.sclr != 0):
       output.write(" scale_rain = "+str(options.sclr)+"\n")

--- a/runcase.py
+++ b/runcase.py
@@ -149,9 +149,9 @@ parser.add_option("--monthly_metdata", dest="monthly_metdata", default = '', \
                   help = "File containing met data (cpl_bypass only)")
 parser.add_option("--add_temperature", dest="addt", default=0.0, \
                   help = 'Temperature to add to atmospheric forcing')
-parser.add_option("--scale_rain", dest="sclr", default=1.0, \
+parser.add_option("--scale_rain", dest="sclr", default='', \
                   help = 'Scaling factor to apply to rain in atmospheric forcing')
-parser.add_option("--scale_snow", dest="scls", default=1.0, \
+parser.add_option("--scale_snow", dest="scls", default='', \
                   help = 'Scaling factor to apply to snowfall in atmospheric forcing')
 parser.add_option("--co2_file", dest="co2_file", default="fco2_datm_rcp4.5_1765-2500_c130312.nc", \
                   help = 'CLM timestep (hours)')
@@ -1647,11 +1647,11 @@ for i in range(1,int(options.ninst)+1):
       output.write(" add_temperature = "+str(options.addt)+"\n")
       output.write(" startdate_add_temperature = '"+str(options.sd_addt)+"'\n")
 
-    if (options.sclr != 1.0):
+    if (options.sclr != ''):
       output.write(" scale_rain = "+str(options.sclr)+"\n")
       output.write(" startdate_scale_rain = '"+str(options.sd_sclr)+"'\n")
 
-    if (options.scls != 1.0):
+    if (options.scls != ''):
       output.write(" scale_snow = "+str(options.scls)+"\n")
       output.write(" startdate_scale_snow = '"+str(options.sd_scls)+"'\n")
     

--- a/runcase.py
+++ b/runcase.py
@@ -149,9 +149,9 @@ parser.add_option("--monthly_metdata", dest="monthly_metdata", default = '', \
                   help = "File containing met data (cpl_bypass only)")
 parser.add_option("--add_temperature", dest="addt", default=0.0, \
                   help = 'Temperature to add to atmospheric forcing')
-parser.add_option("--scale_rain", dest="sclr", default='', \
+parser.add_option("--scale_rain", dest="sclr", default="", \
                   help = 'Scaling factor to apply to rain in atmospheric forcing')
-parser.add_option("--scale_snow", dest="scls", default='', \
+parser.add_option("--scale_snow", dest="scls", default="", \
                   help = 'Scaling factor to apply to snowfall in atmospheric forcing')
 parser.add_option("--co2_file", dest="co2_file", default="fco2_datm_rcp4.5_1765-2500_c130312.nc", \
                   help = 'CLM timestep (hours)')

--- a/site_fullrun.py
+++ b/site_fullrun.py
@@ -124,10 +124,6 @@ parser.add_option("--add_temperature", dest="addt", default=0.0, \
                   help = 'Temperature to add to atmospheric forcing')
 parser.add_option("--startdate_add_temperature", dest="sd_addt", default="99991231", \
                   help = 'Date (YYYYMMDD) to begin addding temperature')
-parser.add_option("--scale_precipitation", dest="sclp", default=1.0, \
-                  help = 'Scaling factor to apply to total precipitation in atmospheric forcing')
-parser.add_option("--startdate_scale_precipitation", dest="sd_sclp", default="99991231", \
-                  help = 'Date (YYYYMMDD) to begin scaling total precipitation')
 parser.add_option("--scale_rain", dest="sclr", default=1.0, \
                   help = 'Scaling factor to apply to rain in atmospheric forcing')
 parser.add_option("--startdate_scale_rain", dest="sd_sclr", default="99991231", \
@@ -632,9 +628,6 @@ for row in AFdatareader:
         if (options.addt != 0):
             basecmd = basecmd+' --add_temperature '+str(options.addt)
             basecmd = basecmd+' --startdate_add_temperature '+str(options.sd_addt)
-        if (options.sclp != 0):
-            basecmd = basecmd+' --scale_precipitation '+str(options.sclp)
-            basecmd = basecmd+' --startdate_scale_precipitation '+str(options.sd_sclp)
         if (options.sclr != 0):
             basecmd = basecmd+' --scale_rain '+str(options.sclr)
             basecmd = basecmd+' --startdate_scale_rain '+str(options.sd_sclr)

--- a/site_fullrun.py
+++ b/site_fullrun.py
@@ -124,11 +124,11 @@ parser.add_option("--add_temperature", dest="addt", default=0.0, \
                   help = 'Temperature to add to atmospheric forcing')
 parser.add_option("--startdate_add_temperature", dest="sd_addt", default="99991231", \
                   help = 'Date (YYYYMMDD) to begin addding temperature')
-parser.add_option("--scale_rain", dest="sclr", default=1.0, \
+parser.add_option("--scale_rain", dest="sclr", default="", \
                   help = 'Scaling factor to apply to rain in atmospheric forcing')
 parser.add_option("--startdate_scale_rain", dest="sd_sclr", default="99991231", \
                   help = 'Date (YYYYMMDD) to begin scaling rain')
-parser.add_option("--scale_snow", dest="scls", default=1.0, \
+parser.add_option("--scale_snow", dest="scls", default="", \
                   help = 'Scaling factor to apply to snowfall in atmospheric forcing')
 parser.add_option("--startdate_scale_snow", dest="sd_scls", default="99991231", \
                   help = 'Date (YYYYMMDD) to begin scaling snowfall')
@@ -628,10 +628,10 @@ for row in AFdatareader:
         if (options.addt != 0):
             basecmd = basecmd+' --add_temperature '+str(options.addt)
             basecmd = basecmd+' --startdate_add_temperature '+str(options.sd_addt)
-        if (options.sclr != 0):
+        if (options.sclr != ''):
             basecmd = basecmd+' --scale_rain '+str(options.sclr)
             basecmd = basecmd+' --startdate_scale_rain '+str(options.sd_sclr)
-        if (options.scls != 0):
+        if (options.scls != ''):
             basecmd = basecmd+' --scale_snow '+str(options.scls)
             basecmd = basecmd+' --startdate_scale_snow '+str(options.sd_scls)
         if (options.addco2 != 0):

--- a/site_fullrun.py
+++ b/site_fullrun.py
@@ -184,6 +184,10 @@ parser.add_option("--C14", dest="C14", default=False, action="store_true", \
                   help = 'Use C14 as C13 (no decay)')
 parser.add_option("--aero_rcp85",dest="aerorcp85", action="store_true", default=False,help="Use RCP8.5 aerosols")
 parser.add_option("--ndep_rcp85",dest="ndeprcp85", action="store_true", default=False,help="Use RCP8.5 N dep")
+parser.add_option("--scale_ndep", dest="scln", default="", \
+                  help = 'Scaling factor to apply to N deposition in atmospheric forcing')
+parser.add_option("--startdate_scale_ndep", dest="sd_scln", default="99991231", \
+                  help = 'Date (YYYYMMDD) to begin scaling N deposition')       
 parser.add_option("--harvmod", action="store_true", dest='harvmod', default=False, \
                   help="turn on harvest modification:  All harvest at first timestep")
 parser.add_option("--no_dynroot", dest="no_dynroot", default=False, action="store_true", \
@@ -654,6 +658,9 @@ for row in AFdatareader:
             basecmd = basecmd + ' --aero_rcp85'
         if (options.ndeprcp85):
             basecmd = basecmd + ' --ndep_rcp85'
+        if (options.scln != ''):
+            basecmd = basecmd+' --scale_ndep '+str(options.scln)
+            basecmd = basecmd+' --startdate_scale_ndep '+str(options.sd_scln)    
         if (options.compiler != ''):
             basecmd = basecmd + ' --compiler '+options.compiler
         basecmd = basecmd + ' --mpilib '+options.mpilib

--- a/site_fullrun.py
+++ b/site_fullrun.py
@@ -126,11 +126,11 @@ parser.add_option("--add_temperature", dest="addt", default=0.0, \
                   help = 'Temperature to add to atmospheric forcing')
 parser.add_option("--startdate_add_temperature", dest="sd_addt", default="99991231", \
                   help = 'Date (YYYYMMDD) to begin addding temperature')
-parser.add_option("--scale_rain", dest="sclr", default=1.0, \
+parser.add_option("--scale_rain", dest="sclr", default="", \
                   help = 'Scaling factor to apply to rain in atmospheric forcing')
 parser.add_option("--startdate_scale_rain", dest="sd_sclr", default="99991231", \
                   help = 'Date (YYYYMMDD) to begin scaling rain')
-parser.add_option("--scale_snow", dest="scls", default=1.0, \
+parser.add_option("--scale_snow", dest="scls", default="", \
                   help = 'Scaling factor to apply to snowfall in atmospheric forcing')
 parser.add_option("--startdate_scale_snow", dest="sd_scls", default="99991231", \
                   help = 'Date (YYYYMMDD) to begin scaling snowfall')
@@ -634,10 +634,10 @@ for row in AFdatareader:
         if (options.addt != 0):
             basecmd = basecmd+' --add_temperature '+str(options.addt)
             basecmd = basecmd+' --startdate_add_temperature '+str(options.sd_addt)
-        if (options.sclr != 1.0):
+        if (options.sclr != ''):
             basecmd = basecmd+' --scale_rain '+str(options.sclr)
             basecmd = basecmd+' --startdate_scale_rain '+str(options.sd_sclr)
-        if (options.scls != 1.0):
+        if (options.scls != ''):
             basecmd = basecmd+' --scale_snow '+str(options.scls)
             basecmd = basecmd+' --startdate_scale_snow '+str(options.sd_scls)
         if (options.addco2 != 0):

--- a/site_fullrun.py
+++ b/site_fullrun.py
@@ -182,6 +182,10 @@ parser.add_option("--C14", dest="C14", default=False, action="store_true", \
                   help = 'Use C14 as C13 (no decay)')
 parser.add_option("--aero_rcp85",dest="aerorcp85", action="store_true", default=False,help="Use RCP8.5 aerosols")
 parser.add_option("--ndep_rcp85",dest="ndeprcp85", action="store_true", default=False,help="Use RCP8.5 N dep")
+parser.add_option("--scale_ndep", dest="scln", default="", \
+                  help = 'Scaling factor to apply to N deposition in atmospheric forcing')
+parser.add_option("--startdate_scale_ndep", dest="sd_scln", default="99991231", \
+                  help = 'Date (YYYYMMDD) to begin scaling N deposition')       
 parser.add_option("--harvmod", action="store_true", dest='harvmod', default=False, \
                   help="turn on harvest modification:  All harvest at first timestep")
 parser.add_option("--no_dynroot", dest="no_dynroot", default=False, action="store_true", \
@@ -647,6 +651,9 @@ for row in AFdatareader:
             basecmd = basecmd + ' --aero_rcp85'
         if (options.ndeprcp85):
             basecmd = basecmd + ' --ndep_rcp85'
+        if (options.scln != ''):
+            basecmd = basecmd+' --scale_ndep '+str(options.scln)
+            basecmd = basecmd+' --startdate_scale_ndep '+str(options.sd_scln)    
         if (options.compiler != ''):
             basecmd = basecmd + ' --compiler '+options.compiler
         basecmd = basecmd + ' --mpilib '+options.mpilib

--- a/site_fullrun.py
+++ b/site_fullrun.py
@@ -187,7 +187,11 @@ parser.add_option("--ndep_rcp85",dest="ndeprcp85", action="store_true", default=
 parser.add_option("--scale_ndep", dest="scln", default="", \
                   help = 'Scaling factor to apply to N deposition in atmospheric forcing')
 parser.add_option("--startdate_scale_ndep", dest="sd_scln", default="99991231", \
-                  help = 'Date (YYYYMMDD) to begin scaling N deposition')       
+                  help = 'Date (YYYYMMDD) to begin scaling N deposition')  
+parser.add_option("--scale_pdep", dest="sclp", default="", \
+                  help = 'Scaling factor to apply to P deposition in atmospheric forcing')
+parser.add_option("--startdate_scale_pdep", dest="sd_sclp", default="99991231", \
+                  help = 'Date (YYYYMMDD) to begin scaling P deposition')            
 parser.add_option("--harvmod", action="store_true", dest='harvmod', default=False, \
                   help="turn on harvest modification:  All harvest at first timestep")
 parser.add_option("--no_dynroot", dest="no_dynroot", default=False, action="store_true", \
@@ -660,7 +664,10 @@ for row in AFdatareader:
             basecmd = basecmd + ' --ndep_rcp85'
         if (options.scln != ''):
             basecmd = basecmd+' --scale_ndep '+str(options.scln)
-            basecmd = basecmd+' --startdate_scale_ndep '+str(options.sd_scln)    
+            basecmd = basecmd+' --startdate_scale_ndep '+str(options.sd_scln)
+        if (options.sclp != ''):
+            basecmd = basecmd+' --scale_pdep '+str(options.sclp)
+            basecmd = basecmd+' --startdate_scale_pdep '+str(options.sd_sclp)      
         if (options.compiler != ''):
             basecmd = basecmd + ' --compiler '+options.compiler
         basecmd = basecmd + ' --mpilib '+options.mpilib

--- a/site_fullrun.py
+++ b/site_fullrun.py
@@ -124,6 +124,18 @@ parser.add_option("--add_temperature", dest="addt", default=0.0, \
                   help = 'Temperature to add to atmospheric forcing')
 parser.add_option("--startdate_add_temperature", dest="sd_addt", default="99991231", \
                   help = 'Date (YYYYMMDD) to begin addding temperature')
+parser.add_option("--scale_precipitation", dest="sclp", default=1.0, \
+                  help = 'Scaling factor to apply to total precipitation in atmospheric forcing')
+parser.add_option("--startdate_scale_precipitation", dest="sd_sclp", default="99991231", \
+                  help = 'Date (YYYYMMDD) to begin scaling total precipitation')
+parser.add_option("--scale_rain", dest="sclr", default=1.0, \
+                  help = 'Scaling factor to apply to rain in atmospheric forcing')
+parser.add_option("--startdate_scale_rain", dest="sd_sclr", default="99991231", \
+                  help = 'Date (YYYYMMDD) to begin scaling rain')
+parser.add_option("--scale_snow", dest="scls", default=1.0, \
+                  help = 'Scaling factor to apply to snowfall in atmospheric forcing')
+parser.add_option("--startdate_scale_snow", dest="sd_scls", default="99991231", \
+                  help = 'Date (YYYYMMDD) to begin scaling snowfall')
 # surface data
 parser.add_option("--surfdata_grid", dest="surfdata_grid", default=False, action="store_true", \
                   help = 'Use gridded surface data instead of site data')
@@ -620,6 +632,15 @@ for row in AFdatareader:
         if (options.addt != 0):
             basecmd = basecmd+' --add_temperature '+str(options.addt)
             basecmd = basecmd+' --startdate_add_temperature '+str(options.sd_addt)
+        if (options.sclp != 0):
+            basecmd = basecmd+' --scale_precipitation '+str(options.sclp)
+            basecmd = basecmd+' --startdate_scale_precipitation '+str(options.sd_sclp)
+        if (options.sclr != 0):
+            basecmd = basecmd+' --scale_rain '+str(options.sclr)
+            basecmd = basecmd+' --startdate_scale_rain '+str(options.sd_sclr)
+        if (options.scls != 0):
+            basecmd = basecmd+' --scale_snow '+str(options.scls)
+            basecmd = basecmd+' --startdate_scale_snow '+str(options.sd_scls)
         if (options.addco2 != 0):
             basecmd = basecmd+' --add_co2 '+str(options.addco2)
             basecmd = basecmd+' --startdate_add_co2 '+str(options.sd_addco2)

--- a/site_fullrun.py
+++ b/site_fullrun.py
@@ -187,7 +187,11 @@ parser.add_option("--ndep_rcp85",dest="ndeprcp85", action="store_true", default=
 parser.add_option("--scale_ndep", dest="scln", default="", \
                   help = 'Scaling factor to apply to N deposition in atmospheric forcing')
 parser.add_option("--startdate_scale_ndep", dest="sd_scln", default="99991231", \
-                  help = 'Date (YYYYMMDD) to begin scaling N deposition')       
+                  help = 'Date (YYYYMMDD) to begin scaling N deposition')  
+parser.add_option("--scale_pdep", dest="sclp", default="", \
+                  help = 'Scaling factor to apply to P deposition in atmospheric forcing')
+parser.add_option("--startdate_scale_pdep", dest="sd_sclp", default="99991231", \
+                  help = 'Date (YYYYMMDD) to begin scaling P deposition')            
 parser.add_option("--harvmod", action="store_true", dest='harvmod', default=False, \
                   help="turn on harvest modification:  All harvest at first timestep")
 parser.add_option("--no_dynroot", dest="no_dynroot", default=False, action="store_true", \
@@ -660,7 +664,10 @@ for row in AFdatareader:
             basecmd = basecmd + ' --ndep_rcp85'
         if (options.scln != ''):
             basecmd = basecmd+' --scale_ndep '+str(options.scln)
-            basecmd = basecmd+' --startdate_scale_ndep '+str(options.sd_scln)    
+            basecmd = basecmd+' --startdate_scale_ndep '+str(options.sd_scln)
+        if (options.sclp != ''):
+            basecmd = basecmd+' --scale_pdep '+str(options.sclp)
+            basecmd = basecmd+' --startdate_scale_npep '+str(options.sd_sclp)      
         if (options.compiler != ''):
             basecmd = basecmd + ' --compiler '+options.compiler
         basecmd = basecmd + ' --mpilib '+options.mpilib


### PR DESCRIPTION
Adds ndep/pdep scaling options to OLMT scripts; updates precipitation scaling options so that they are unset when not specified (and hence, underlying ELM version need not have these namelist variables unless these options are set).

Still working on a few changes to ELM to go along with this, will open a separate PR when completed.