### PR TITLE
Fix bug in transient docker script for non-kougarok sites

### DIFF
--- a/examples/site_fullrun_docker_transient_nyears.sh
+++ b/examples/site_fullrun_docker_transient_nyears.sh
@@ -61,8 +61,8 @@ if [ ! -d ${ELM_USER_DATA} ]; then
 fi
 cd ${ELM_USER_DATA}
 
-if [ ! ${site_name} = kougarok ] ; then
-  if [ ${ncfile_init} = /tools/OLMT/examples/site_fullrun_docker_tr_demo_fini.nc ]; then
+if [ ${ncfile_init} = /tools/OLMT/examples/site_fullrun_docker_tr_demo_fini.nc ]; then
+  if [ ! ${site_name} = kougarok ] ; then
      # this file in OLMT/examples/ is specifically for kougarok site only
      echo " "
      echo "**** EXECUTION HALTED ****"


### PR DESCRIPTION
For site other than Kougarok, the script would not copy the initial condition. Fixed this by reversing the if nesting.